### PR TITLE
/issues/5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,8 +51,9 @@ class java8 {
       apt::ppa { 'ppa:webupd8team/java': }
 
       exec { 'apt-update':
-        command => '/usr/bin/apt-get update',
-        require => [
+        command     => '/usr/bin/apt-get update',
+        refreshonly => true,
+        subscribe   => [
           Apt::Ppa['ppa:webupd8team/java']
         ],
       }


### PR DESCRIPTION
Tested on Ubuntu 14.04 only.  This fixes exec from being called every
time.  This fix only applies to Ubuntu.
